### PR TITLE
feat: Implement configurable dataset limit

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -27,6 +27,7 @@ class DataConfig(Struct):
     path: str
     type: DataType
     format: DataFormat
+    limit: int | None = None
 
 class ProcessesConfig(Struct):
     parallel: int

--- a/src/datasets.py
+++ b/src/datasets.py
@@ -52,6 +52,11 @@ def load_dataset(config: Config) -> Result[list[Request]]:
         return Err(ds.unwrap_err())
         
     df = ds.unwrap()
+
+    if config.data.limit is not None and config.data.limit > 0:
+        limit = min(config.data.limit, len(df))
+        df = df.slice(0, limit)
+
     return convert_to_request(df, config)
 
 @Result.resultify


### PR DESCRIPTION
This commit introduces a configurable limit for input datasets.

The following changes were made:
- Added an optional `limit` field to the `DataConfig` class in `src/config.py`. This allows you to specify a maximum number of records to load from the input dataset.
- Updated the `load_dataset` function in `src/datasets.py` to honor this `limit`. If a limit is provided in the configuration, the loaded DataFrame will be sliced to that number of records before being converted into requests.

This feature provides you with more control over the data processing pipeline, especially useful for testing with smaller subsets of large datasets or for managing resource consumption.