### PR TITLE
feat: Implement scaffolding for verification worker

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -38,12 +38,18 @@ class OutputConfig(Struct):
     format: DataFormat | None = None
     checkpoint_interval: int | None = None
 
+class VerificationConfig(Struct):
+    # Placeholder for future verification-specific configurations
+    # For example, could specify a script path or module for the verification_fn
+    enabled: bool = True # By default, verification is enabled if the section exists
+
 class Config(Struct):
     api: APIConfig
     model: ModelConfig
     data: DataConfig
     processes: ProcessesConfig
     output: OutputConfig | None = None
+    verification: VerificationConfig | None = None # Added verification config
 
     @Result.resultify
     @staticmethod


### PR DESCRIPTION
- Add a `verification_worker` that processes requests and uses a `verification_fn` to determine if a request is valid.
- If valid, the request is sent to the output queue.
- If invalid, the request is sent back to the input queue.
- Add a placeholder `verification_fn` that always returns True.
- Add `VerificationConfig` to `config.py` for future verification-specific settings.
- Update `main.py` to use the new worker.